### PR TITLE
Add critical health check for number of workers on cooldown

### DIFF
--- a/src/checks/critical.js
+++ b/src/checks/critical.js
@@ -1,3 +1,4 @@
+const util = require("node:util");
 const got = require("got");
 const FormData = require("form-data");
 const { isEqual } = require("lodash");
@@ -143,7 +144,15 @@ async function registryWriteAndReadCheck(done) {
     if (isEqual(expected, entry)) {
       data.up = true;
     } else {
-      data.errors = [{ message: "Data mismatch in registry (read after write)", entry, expected }];
+      data.errors = [
+        {
+          message: "Data mismatch in registry (read after write)",
+          // use util.inspect to serialize the entries, otherwise built in JSON.stringify will throw error
+          // on revision being BigInt (unsupported) and data will not be printed properly as Uint8Array
+          received: util.inspect(entry, { breakLength: Infinity, compact: true }),
+          expected: util.inspect(expected, { breakLength: Infinity, compact: true }),
+        },
+      ];
     }
   } catch (error) {
     data.errors = [{ message: error?.response?.data?.message ?? error.message }];


### PR DESCRIPTION
- added new critical health check that fails when number of workers on cooldown to total number of workers ratio is more than a certain threshold (currently set to 60%)
- dropped passing external server ip on local skyd check (would falsely report error every time, harmless since it was just printing that when real issue occurred but pretty confusing)
- critical fix: registry entry debug serialiser was failing since entries have BigInt revision (whole health check fails to finish if that happens, very critical bug fix)