### PR TITLE
support new env variable for blocking public access

### DIFF
--- a/src/api/disabled.js
+++ b/src/api/disabled.js
@@ -5,5 +5,5 @@ const { getDisabledServerReason } = require("../utils");
 module.exports = (req, res) => {
   const manualDisabledReason = db.get("disabled").value();
 
-  return getDisabledServerReason(manualDisabledReason);
+  res.send({ disabled: getDisabledServerReason(manualDisabledReason) });
 };

--- a/src/api/disabled.js
+++ b/src/api/disabled.js
@@ -1,8 +1,9 @@
 const db = require("../db");
+const { getDisabledServerReason } = require("../utils");
 
 // returns a disabled flag status
 module.exports = (req, res) => {
-  const disabled = db.get("disabled").value();
+  const manualDisabledReason = db.get("disabled").value();
 
-  res.send({ disabled });
+  return getDisabledServerReason(manualDisabledReason);
 };

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,6 +1,7 @@
 const { StatusCodes } = require("http-status-codes");
 const { sum, sumBy } = require("lodash");
 const db = require("../db");
+const { getDisabledServerReason } = require("../utils");
 
 /**
  * Get status code that should be returned in the API response.
@@ -54,7 +55,9 @@ function getMostRecentCriticalEntry() {
  * Get the disabled flag state (manual portal disable)
  */
 function getDisabled() {
-  return db.get("disabled").value();
+  const manualDisabledReason = db.get("disabled").value();
+
+  return getDisabledServerReason(manualDisabledReason);
 }
 
 module.exports = (req, res) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -138,10 +138,10 @@ function isPortalModuleEnabled(module) {
  * - DENY_PUBLIC_ACCESS env variable is set to true (server on takedown)
  */
 function getDisabledServerReason(manualDisabledReason) {
-  const accessDeniedReason = "Server public access denied"; // generic reason message
-
   // check if a flag that indicates that server should disable public traffic is enabled
   if (process.env.DENY_PUBLIC_ACCESS === "true") {
+    const accessDeniedReason = "Server public access denied"; // generic reason message
+
     // include manual disable reason if server has been manually disabled
     return manualDisabledReason ? `${manualDisabledReason} & ${accessDeniedReason}` : accessDeniedReason;
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -132,6 +132,23 @@ function isPortalModuleEnabled(module) {
   return process.env.PORTAL_MODULES && process.env.PORTAL_MODULES.indexOf(module) !== -1;
 }
 
+/**
+ * Compute and generate a message indicating a disabled server. Server is disabled when either:
+ * - disable reason is set manually (non empty)
+ * - DENY_PUBLIC_ACCESS env variable is set to true (server on takedown)
+ */
+function getDisabledServerReason(manualDisabledReason) {
+  const accessDeniedReason = "Server public access denied"; // generic reason message
+
+  // check if a flag that indicates that server should disable public traffic is enabled
+  if (process.env.DENY_PUBLIC_ACCESS === "true") {
+    // include manual disable reason if server has been manually disabled
+    return manualDisabledReason ? `${manualDisabledReason} & ${accessDeniedReason}` : accessDeniedReason;
+  }
+
+  return manualDisabledReason;
+}
+
 module.exports = {
   calculateElapsedTime,
   getYesterdayISOString,
@@ -139,6 +156,7 @@ module.exports = {
   ensureValidJSON,
   getAuthCookie,
   isPortalModuleEnabled,
+  getDisabledServerReason,
   ipCheckService,
   ipRegex,
 };


### PR DESCRIPTION
Server is disabled when either:
- disable reason is set manually (non empty)
- DENY_PUBLIC_ACCESS env variable is set to true (server on takedown)

Additionally displays a proper disable message when using DENY_PUBLIC_ACCESS.