### PR TITLE
expose /health-check/whatismyip endpoint

### DIFF
--- a/src/api/whatismyip.js
+++ b/src/api/whatismyip.js
@@ -1,0 +1,3 @@
+module.exports = (req, res) => {
+  res.send(process.env.serverip); // variable set during docker image startup
+};

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ server.get("/health-check", require("./api/index"));
 server.get("/health-check/critical", require("./api/critical"));
 server.get("/health-check/extended", require("./api/extended"));
 server.get("/health-check/disabled", require("./api/disabled"));
+server.get("/health-check/whatismyip", require("./api/whatismyip"));
 
 server.listen(port, host, (error) => {
   if (error) throw error;


### PR DESCRIPTION
health-check service pulls the server public ip on startup, it makes sense to expose it for other services to use (I'm gonna need it in nginx for my work on blocking external traffic access for takedown servers)

otherwise we could create new service and expose it there but I'm not sure it makes much sense to add this complexity